### PR TITLE
luci-mod-admin-full: allow writing empty crontab config

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/crontab.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/crontab.lua
@@ -19,6 +19,8 @@ function f.handle(self, state, data)
 		if data.crons then
 			fs.writefile(cronfile, data.crons:gsub("\r\n", "\n"))
 			luci.sys.call("/usr/bin/crontab %q" % cronfile)
+		else
+			fs.writefile(cronfile, "")
 		end
 	end
 	return true


### PR DESCRIPTION
Write an empty crontab file to remove all content
from file /etc/crontabs/root

Signed-off-by: Florian Eckert Eckert.Florian@googlemail.com
